### PR TITLE
fix: syntax error in ghciwatch command causing ghciwatch to error out when multiple hs files are in the app folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ repl: update
 	wasm32-wasi-cabal repl app -finteractive --repl-options='-fghci-browser -fghci-browser-port=8080'
 
 watch:
-	ghciwatch --after-startup-ghci :main --after-reload-ghci :main --watch app/*.hs --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
+	ghciwatch --after-startup-ghci :main --after-reload-ghci :main --watch app --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
 
 build:
 	wasm32-wasi-cabal build 


### PR DESCRIPTION
`--watch app/*.hs` gets expanded to `--watch app/File1.hs app/File2.hs` which is unsupported and causes the following error:

```
ghciwatch --after-startup-ghci :main --after-reload-ghci :main --watch app/*.hs --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
error: the argument '[FILE]' cannot be used with '--command <SHELL_COMMAND>'

Usage: ghciwatch [--command SHELL_COMMAND] [--watch PATH] [OPTIONS ...]

For more information, try '--help'.
make: *** [Makefile:18: watch] Error 2
```

According to the docs the correct syntax is `--watch app` or `--watch app/File1.hs --watch app/File2.hs`. https://mercurytechnologies.github.io/ghciwatch/cli.html#--watch

This PR simply uses `--watch app`.